### PR TITLE
Fix golint path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ vet:
 	@go vet ${PACKAGES}
 
 lint:
-	@ go get -v github.com/golang/lint/golint
+	@ go get -v golang.org/x/lint/golint
 	$(foreach file,$(SRCS),golint $(file) || exit;)
 
 image: test


### PR DESCRIPTION
Update as per official golang lint changes: golang/lint#415