### PR TITLE
Add support for DistributionInspect action

### DIFF
--- a/core/route_parser.go
+++ b/core/route_parser.go
@@ -178,6 +178,8 @@ var routes = []route{
 	{pattern: "/configs/.+", method: "DELETE", action: ActionConfigDelete},
 	// https://docs.docker.com/engine/api/v1.39/#operation/ConfigList
 	{pattern: "/configs", method: "GET", action: ActionConfigList},
+	// https://docs.docker.com/engine/api/v1.39/#operation/DistributionInspect
+	{pattern: "/distribution/.+/json", method: "GET", action: ActionDistributionInspect},
 }
 
 // ParseRoute convert a method/url pattern to corresponding docker action

--- a/core/route_parser_test.go
+++ b/core/route_parser_test.go
@@ -92,6 +92,7 @@ func TestRouteParser(t *testing.T) {
 		{"GET", "/v1.39/configs/id", ActionConfigInspect},
 		{"DELETE", "/v1.39/configs/id", ActionConfigDelete},
 		{"POST", "/v1.39/configs/id/update", ActionConfigUpdate},
+		{"GET", "/v1.39/distribution/twistlock/authz-broker:latest/json", ActionDistributionInspect},
 	}
 
 	for _, test := range tests {

--- a/core/types.go
+++ b/core/types.go
@@ -170,6 +170,8 @@ var (
 	ActionConfigDelete = "config_delete"
 	// ActionConfigUpdate describes https://docs.docker.com/engine/api/v1.39/#operation/ConfigUpdate
 	ActionConfigUpdate = "config_update"
+	// ActionDistributionInspect describes https://docs.docker.com/engine/api/v1.39/#operation/DistributionInspect
+	ActionDistributionInspect = "distribution_inspect"
 	// ActionNone indicates no action matched the given method URL combination
 	ActionNone = ""
 )


### PR DESCRIPTION
This action is used by "docker service create" to retreive the image's
digest and platform.

See https://github.com/moby/moby/blob/42a054473bc650755e0db66eb5d17895946e20f6/client/service_create.go#L90