### PR TITLE
Correct error /events method

### DIFF
--- a/core/route_parser.go
+++ b/core/route_parser.go
@@ -16,7 +16,7 @@ var routes = []route{
 	// https://docs.docker.com/reference/api/docker_remote_api_v1.20/#create-a-new-image-from-a-container-s-changes
 	{pattern: "/commit", method: "POST", action: ActionContainerCommit},
 	// https://docs.docker.com/reference/api/docker_remote_api_v1.20/#monitor-docker-s-events
-	{pattern: "/events", method: "POST", action: ActionDockerEvents},
+	{pattern: "/events", method: "GET", action: ActionDockerEvents},
 	// https://docs.docker.com/reference/api/docker_remote_api_v1.20/#show-the-docker-version-information
 	{pattern: "/version", method: "GET", action: ActionDockerVersion},
 	// https://docs.docker.com/reference/api/docker_remote_api_v1.20/#check-auth-configuration


### PR DESCRIPTION
If you see the following documentation : https://docs.docker.com/engine/api/v1.20/ is not a POST method but a GET method.